### PR TITLE
Move light name property to object, fix light helper init

### DIFF
--- a/libs/ff-scene/source/components/CLight.ts
+++ b/libs/ff-scene/source/components/CLight.ts
@@ -27,6 +27,7 @@ export default class CLight extends CObject3D
     canDelete: boolean = true;
 
     protected static readonly lightIns = {
+        name: types.String("Light.Name"), 
         enabled: types.Boolean("Light.Enabled", true),
         color: types.ColorRGB("Light.Color"),
         intensity: types.Number("Light.Intensity", {
@@ -55,6 +56,10 @@ export default class CLight extends CObject3D
 
         const light = this.light;
         const ins = this.ins;
+
+        if (ins.name.changed) {
+            this.node.name = ins.name.value;
+        }
 
         if(ins.enabled.changed) {
             light.visible = ins.enabled.value;

--- a/source/client/components/CVScene.ts
+++ b/source/client/components/CVScene.ts
@@ -63,6 +63,7 @@ export default class CVScene extends CVNode
     protected static readonly ins = {
         units: types.Enum("Scene.Units", EUnitType, EUnitType.cm),
         modelUpdated: types.Event("Scene.ModelUpdated"),
+        lightUpdated: types.Event("Scene.LightUpdated"),
         sceneTransformed: types.Event("Scene.Transformed"),
     };
 
@@ -133,6 +134,9 @@ export default class CVScene extends CVNode
         }
         if (ins.sceneTransformed.changed) {
             this.updateModelBoundingBox();
+        }
+        if (ins.lightUpdated.changed) {
+            this.updateLights();
         }
 
         return true;

--- a/source/client/components/lights/CVAmbientLight.ts
+++ b/source/client/components/lights/CVAmbientLight.ts
@@ -33,6 +33,7 @@ export default class CVAmbienLight extends CAmbientLight implements ICVLight
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -63,6 +64,7 @@ export default class CVAmbienLight extends CAmbientLight implements ICVLight
             throw new Error("light type mismatch: not an ambient light");
         }
 
+        ins.name.setValue(node.name);
         data.point = data.point || {} as any;
 
         ins.copyValues({

--- a/source/client/components/lights/CVDirectionalLight.ts
+++ b/source/client/components/lights/CVDirectionalLight.ts
@@ -36,6 +36,7 @@ export default class CVDirectionalLight extends CDirectionalLight implements ICV
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -74,6 +75,8 @@ export default class CVDirectionalLight extends CDirectionalLight implements ICV
         if (data.type !== "directional") {
             throw new Error("light type mismatch: not a directional light");
         }
+
+        ins.name.setValue(node.name);
 
         ins.copyValues({
             enabled: data.enabled !== undefined ? data.enabled : ins.enabled.schema.preset,

--- a/source/client/components/lights/CVHemisphereLight.ts
+++ b/source/client/components/lights/CVHemisphereLight.ts
@@ -33,6 +33,7 @@ export default class CVHemisphereLight extends CHemisphereLight implements ICVLi
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -65,6 +66,7 @@ export default class CVHemisphereLight extends CHemisphereLight implements ICVLi
             throw new Error("light type mismatch: not an hemisphere light");
         }
 
+        ins.name.setValue(node.name);
         data.point = data.point || {} as any;
 
         ins.copyValues({

--- a/source/client/components/lights/CVPointLight.ts
+++ b/source/client/components/lights/CVPointLight.ts
@@ -34,6 +34,7 @@ export default class CVPointLight extends CPointLight implements ICVLight
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -74,6 +75,7 @@ export default class CVPointLight extends CPointLight implements ICVLight
             throw new Error("light type mismatch: not a point light");
         }
 
+        ins.name.setValue(node.name);
         data.point = data.point || {} as any;
 
         ins.copyValues({

--- a/source/client/components/lights/CVRectLight.ts
+++ b/source/client/components/lights/CVRectLight.ts
@@ -33,6 +33,7 @@ export default class CVRectLight extends CRectLight implements ICVLight
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -62,6 +63,8 @@ export default class CVRectLight extends CRectLight implements ICVLight
         if (data.type !== CVRectLight.type) {
             throw new Error(`light type mismatch: not a directional light (${data.type})`);
         }
+
+        ins.name.setValue(node.name);
 
         ins.copyValues({
             enabled: data.enabled !== undefined ? data.enabled : ins.enabled.schema.preset,

--- a/source/client/components/lights/CVSpotLight.ts
+++ b/source/client/components/lights/CVSpotLight.ts
@@ -34,6 +34,7 @@ export default class CVSpotLight extends CSpotLight implements ICVLight
 
     get settingProperties() {
         return [
+            this.ins.name,
             this.ins.enabled,
             this.ins.color,
             this.ins.intensity,
@@ -76,6 +77,7 @@ export default class CVSpotLight extends CSpotLight implements ICVLight
             throw new Error("light type mismatch: not a spot light");
         }
 
+        ins.name.setValue(node.name);
         data.spot = data.spot || {} as any;
 
         ins.copyValues({

--- a/source/client/ui/story/NodeTree.ts
+++ b/source/client/ui/story/NodeTree.ts
@@ -29,6 +29,7 @@ import NVScene from "../../nodes/NVScene";
 import CLight from "@ff/scene/components/CLight";
 import ConfirmDeleteLightMenu from "./ConfirmDeleteLightMenu";
 import CreateLightMenu from "./CreateLightMenu";
+import CVScene from "client/components/CVScene";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -204,8 +205,11 @@ class NodeTree extends Tree<NVNode>
         if (!lightType) throw new Error(`Unsupported light type: '${newType}'`);
 
         const lightNode: NVNode = parentNode.graph.createCustomNode(parentNode);
-        lightNode.transform.createComponent<ICVLight>(lightType);
-        lightNode.name = name;
+        const newLight: ICVLight = lightNode.transform.createComponent<ICVLight>(lightType);
+        newLight.ins.name.setValue(name);
+        newLight.update(this);  // trigger light update before helper creation to ensure proper init
+
+        newLight.getGraphComponent(CVScene).ins.lightUpdated.set();
 
         return lightNode;
     }

--- a/source/client/ui/story/SettingsTaskView.ts
+++ b/source/client/ui/story/SettingsTaskView.ts
@@ -42,14 +42,6 @@ import NodeTree from "./NodeTree";
 @customElement("sv-settings-task-view")
 export default class SettingsTaskView extends TaskView<CVSettingsTask>
 {
-    protected onLightNameInput(e: InputEvent) {
-        const input = e.target as HTMLInputElement;
-        if (this.activeNode) {
-            this.activeNode.name = input.value;
-            this.requestUpdate();
-        }
-    }
-
     protected onLightTypeChange(e: Event) {
         const select = e.target as HTMLSelectElement;
         const newType = parseInt(select.value) as ELightType;
@@ -97,8 +89,6 @@ export default class SettingsTaskView extends TaskView<CVSettingsTask>
         return html`<div class="ff-flex-item-stretch ff-scroll-y ff-flex-column">
             ${(node.light && !(node.light instanceof CVEnvironmentLight)) ? html`<div class="ff-group" style="padding:4px 8px;">
                 <div class="ff-flex-row" style="align-items:center; gap:6px;">
-                    <label class="ff-label">${languageManager.getUILocalizedString("Name")}</label>
-                    <input class="ff-input sv-light-name-input" type="text" .value=${node.name} @input=${(e: InputEvent) => this.onLightNameInput(e)} />
                     <label class="ff-label">${languageManager.getUILocalizedString("Type")}</label>
                     <select class="ff-input" .value=${currentType ?? 0} @change=${(e: Event) => this.onLightTypeChange(e)}>
                         ${Object.keys(ELightType).filter(key => typeof (ELightType as any)[key] === "number").map(key => html`<option value=${(ELightType as any)[key]}>${key}</option>`)}


### PR DESCRIPTION
From https://github.com/Smithsonian/dpo-voyager/pull/374#issuecomment-3559995438:

 
>  -    moved 'name' property to the light objects
>  -    fixed issue where new light helpers (particularly directional helpers) don't initialize properly when created via UI

